### PR TITLE
bugfix-json-console-logger: Fixed method signature

### DIFF
--- a/Classes/Backend/JSONConsoleLogger.php
+++ b/Classes/Backend/JSONConsoleLogger.php
@@ -35,8 +35,9 @@ class JSONConsoleLogger extends ConsoleBackend
     /**
      * @param mixed $additionalData A variable containing more information about the event to be logged
      */
-    public function append(string $message, string $packageKey, string $className, string $methodName, int $severity = LOG_INFO, $additionalData = null): void
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
+
         if ($severity > $this->severityThreshold) {
             return;
         }

--- a/Classes/Backend/JSONConsoleLogger.php
+++ b/Classes/Backend/JSONConsoleLogger.php
@@ -37,7 +37,6 @@ class JSONConsoleLogger extends ConsoleBackend
      */
     public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
-
         if ($severity > $this->severityThreshold) {
             return;
         }


### PR DESCRIPTION
Did an oopsie with the signature (because it changed with neos / flow 7)